### PR TITLE
Use mach-nix to add zephyr requirements to nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,12 @@ let inherit (lib) ;
   }) {
     python = "python3";
   };
+  zephyr-requirements = fetchurl {
+    url = "https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v2.5.0/scripts/requirements-base.txt";
+    sha256 = "919a78ba9457a8e55451450329158ff7fdcbc4a2ddb0dd76ea804c3b04a3c6c6";
+  };
   machNix = mach-nix.mkPython rec {
-    requirements = builtins.readFile ./zephyr/scripts/requirements-base.txt;
+    requirements = builtins.readFile zephyr-requirements;
   };
 in mkShell {
   buildInputs = [

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ let inherit (lib) ;
     url = "https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v2.5.0/scripts/requirements-base.txt";
     sha256 = "919a78ba9457a8e55451450329158ff7fdcbc4a2ddb0dd76ea804c3b04a3c6c6";
   };
-  machNix = mach-nix.mkPython rec {
+  python-pkgs = mach-nix.mkPython rec {
     requirements = builtins.readFile zephyr-requirements;
   };
 in mkShell {
@@ -24,7 +24,7 @@ in mkShell {
     dtc
     dfu-util
     gcc-arm-embedded
-    machNix
+    python-pkgs
   ];
 
   shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,15 @@
 with pkgs;
 
 let inherit (lib) ;
+  mach-nix = import (builtins.fetchGit {
+    url = "https://github.com/DavHau/mach-nix";
+    ref = "master";
+  }) {
+    python = "python3";
+  };
+  machNix = mach-nix.mkPython rec {
+    requirements = builtins.readFile ./zephyr/scripts/requirements-base.txt;
+  };
 in mkShell {
   buildInputs = [
     cmake
@@ -11,9 +20,7 @@ in mkShell {
     dtc
     dfu-util
     gcc-arm-embedded
-    python3
-    python38Packages.west
-    python38Packages.pip
+    machNix
   ];
 
   shellHook = ''


### PR DESCRIPTION
As per your suggestion in https://github.com/zmkfirmware/zmk/pull/1026#issuecomment-985883000, use [`mach-nix`](https://github.com/DavHau/mach-nix/blob/master/examples.md#mkpython--mkpythonshell) to handle the python environment, reading zephyr's python dependencies from `zephyr/scripts/requirements.txt`.